### PR TITLE
refactor: openAi prompt to return arrays

### DIFF
--- a/app/api/openai/processTranscript.ts
+++ b/app/api/openai/processTranscript.ts
@@ -75,6 +75,6 @@ transcript: """${transcription}"""
   if (!formattedResponse) {
     throw new Error("Failed to parse the formatted response as JSON")
   }
-  console.log(formattedResponse)
+
   return formattedResponse
 }

--- a/app/api/openai/processTranscript.ts
+++ b/app/api/openai/processTranscript.ts
@@ -6,9 +6,9 @@ import { callGetTranscriptEntry } from "../google-meet/getTranscript"
 
 type FormattedResponse = {
   title: string
-  attendees: string
-  "key discussion points": string
-  actions: string
+  attendees: string[]
+  keyDiscussionPoints: string[]
+  actions: string[]
 }
 
 const openai = new OpenAI({
@@ -35,9 +35,9 @@ export async function processTranscript(): Promise<FormattedResponse> {
 """
 {
 "title": "curriculum meeting",
-"attendees": "John, Paula, Mike",
-"key discussion points" :  "Reviewed student progress and performance in the current cohort", "Discussed upcoming curriculum changes and improvements", "Addressed the need for additional support for struggling students",
-"actions":  "John to conduct weekly check-ins with struggling students", "Mike to email all students with schedule changes", "Paula to create a new curriculum proposal"
+"attendees": ["John", "Paula", "Mike"],
+"keyDiscussionPoints":  ["Reviewed student progress and performance in the current cohort", "Discussed upcoming curriculum changes and improvements", "Addressed the need for additional support for struggling students"],
+"actions":  ["John to conduct weekly check-ins with struggling students", "Mike to email all students with schedule changes", "Paula to create a new curriculum proposal"]
 }
 """
 
@@ -75,6 +75,6 @@ transcript: """${transcription}"""
   if (!formattedResponse) {
     throw new Error("Failed to parse the formatted response as JSON")
   }
-
+  console.log(formattedResponse)
   return formattedResponse
 }

--- a/app/components/SelectedTranscript.tsx
+++ b/app/components/SelectedTranscript.tsx
@@ -21,19 +21,35 @@ export const SelectedTranscript: React.FC<SelectedTranscriptProps> = ({
         {latestDoc ? latestDoc.title : "Meeting title"}
       </h1>
       <h2 className="mt-8 mb-5">Attendees</h2>
-      <p>{latestDoc ? latestDoc.attendees : "Meeting attendees"}</p>
-      <h2 className="mt-8 mb-5">key discussion points</h2>
-      {latestDoc
-        ? discussionPoints.map((item: string, index: number) => (
+      {latestDoc && latestDoc.attendees ? (
+        <ul>
+          {latestDoc.attendees.map((attendee: string, index: number) => (
+            <li key={index}>{attendee}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>Meeting attendees will be listed here.</p>
+      )}
+      <h2 className="mt-8 mb-5">Key Discussion Points</h2>
+      {latestDoc && latestDoc.keyDiscussionPoints ? (
+        <ul>
+          {latestDoc.keyDiscussionPoints.map((item: string, index: number) => (
             <li key={index}>{item}</li>
-          ))
-        : "key discussion points will go here"}
-      <h2 className="mt-8 mb-5"> Actions </h2>
-      {latestDoc
-        ? latestDoc.actions.map((item: string, index: number) => (
+          ))}
+        </ul>
+      ) : (
+        <p>Key discussion points will go here.</p>
+      )}
+      <h2 className="mt-8 mb-5">Actions</h2>
+      {latestDoc && latestDoc.actions ? (
+        <ul>
+          {latestDoc.actions.map((item: string, index: number) => (
             <li key={index}>{item}</li>
-          ))
-        : "actions will go here"}
+          ))}
+        </ul>
+      ) : (
+        <p>Actions will go here.</p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
closes #57 

This pr contains a refactor of the openAi prompt in order to satisfy the criteria set out during the project mapping K9 

"I will record any principles of algorithms, logic, and data structures relevant to the project development and justify my choices in my project report. For example, arrays and lists could be used to store sequential data such as the transcribed text or the summarised outputs. They’re also useful for managing lists of action items or keywords extracted from the meeting notes."

Previously, the api call returned an object with multiple string values. Now, it returns an object with arrays of strings as the values and therefore uses arrays as I originally stated it would do.